### PR TITLE
modify: 升级依赖、修复安全配置、优化交互体验

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm outdated *)"
+    ]
+  }
+}

--- a/electron/lib/fs.js
+++ b/electron/lib/fs.js
@@ -43,13 +43,11 @@ function save(fileName, data, callback) {
  * @param data
  */
 function saveSync(fileName, data) {
-  fs.writeFileSync(getPath(fileName), data, (err) => {
-    if (err) {
-      console.log("save error " + err);
-      return;
-    }
-    console.log("Data written successfully to disk");
-  });
+  try {
+    fs.writeFileSync(getPath(fileName), data);
+  } catch (err) {
+    console.log("saveSync error " + err);
+  }
 }
 
 /**

--- a/electron/lib/util/utils.js
+++ b/electron/lib/util/utils.js
@@ -6,7 +6,7 @@ import crypto from "crypto";
  * @returns {String|string}
  */
 function parseString(data) {
-    return data instanceof String ? data : JSON.stringify(data);
+    return typeof data === 'string' ? data : JSON.stringify(data);
 }
 
 

--- a/electron/listen/action/dataSyncAction.js
+++ b/electron/listen/action/dataSyncAction.js
@@ -1,31 +1,23 @@
 import { ipcMain } from "electron";
-import {eventName} from "../../lib/metadata/event";
+import { eventName } from "../../lib/metadata/event";
 import { save, access, readdirSync, statSync } from "../../lib/fs";
-import {fileName, fileTypeList, getPath} from "../../lib/metadata/metadata";
+import { fileName, fileTypeList, getPath } from "../../lib/metadata/metadata";
 import path from "path";
 import mime from "mime-types";
 import { CharConstants } from "../../constants/constant";
-import {formatTime, getMd5Value} from "../../lib/util/utils";
-
-const { parseFile } = require("music-metadata");
-import {fileTypeFromBuffer} from 'file-type';
-
+import { formatTime, getMd5Value } from "../../lib/util/utils";
+import { parseFile } from "music-metadata";
+import { fileTypeFromBuffer } from "file-type";
 
 function readDir(dir, fileList) {
   try {
     let files = readdirSync(dir);
-    if (files === null || files === undefined) {
-      return;
-    }
+    if (!files) return;
     files.forEach((file) => {
       let filePath = path.join(dir, file);
       let info = statSync(filePath);
       if (info.isFile()) {
-        fileList.push({
-          dir: dir,
-          filePath: filePath,
-          hashCode: getMd5Value(filePath),
-        });
+        fileList.push({ dir, filePath, hashCode: getMd5Value(filePath) });
       } else {
         readDir(filePath, fileList);
       }
@@ -35,64 +27,44 @@ function readDir(dir, fileList) {
   }
 }
 
-/**
- * 获取文件夹下的文件
- * @param dirs
- */
 function batchReadDir(dirs) {
-  //解析文件
   let fileList = [];
-  dirs.forEach((dir) => {
-    readDir(dir, fileList);
-  });
+  dirs.forEach((dir) => readDir(dir, fileList));
   return fileList;
 }
 
-function savePicture(data, value, metadata, hashCode) {
-  //存储二进制图片
-  let picture = data.common.picture[0].data;
+async function savePicture(data, metadata, hashCode) {
+  const picture = data.common.picture[0].data;
+  const fileInfo = await fileTypeFromBuffer(picture);
+  if (fileInfo) {
+    metadata.pictureMime = fileInfo.mime;
+    metadata.pictureExt = fileInfo.ext;
+  }
 
-  fileTypeFromBuffer(picture).then(res => {
-    metadata.pictureMime = res.mime
-    metadata.pictureExt = res.ext
-  })
-  //获取文件后缀
-  let imageMimeType = data.common.picture[0].format;
-  let format = mime.extension(imageMimeType);
-
-  let pictureName = hashCode + CharConstants.DOT + format;
-  let picturePath = getPath(pictureName);
+  const imageMimeType = data.common.picture[0].format;
+  const format = mime.extension(imageMimeType) || metadata.pictureExt || 'png';
+  const pictureName = hashCode + CharConstants.DOT + format;
+  const picturePath = getPath(pictureName);
   metadata.picture = picturePath;
 
-  //文件不存在则写入
   access(picturePath, (err) => {
-    if (err) {
-      save(pictureName, picture);
-    }
+    if (err) save(pictureName, picture);
   });
 }
 
-/**
- * 父级目录，文件路径
- * @param {[]} fileList 父级目录，文件信息对象{文件标题等}
- * @param callback function
- * @param event electron 事件
- */
 function parseMetaData(fileList, callback, event) {
   if (fileList.length === 0) {
-    //回调前端
     callback(fileList, event);
+    return;
   }
   let metaList = [];
-  let mapSize = fileList.length;
+  let remaining = fileList.length;
   let key = 1;
 
-  //循环解析音乐元数据
   fileList.forEach((value) => {
-    let promise = parseFile(value.filePath);
-    promise
-      .then((data) => {
-        if (data !== null && data !== undefined && fileTypeList.includes(data.format.container)) {
+    parseFile(value.filePath)
+      .then(async (data) => {
+        if (data && fileTypeList.includes(data.format.container)) {
           let metadata = {
             key: key,
             title: data.common.title,
@@ -105,85 +77,58 @@ function parseMetaData(fileList, callback, event) {
             path: value.filePath,
             duration: formatTime(data.format.duration),
             type: data.format.container ? data.format.container.toLowerCase() : 'mp3',
-            mime: data.format.container ? 'audio/'+data.format.container.toLowerCase() : 'audio/mp3',
+            mime: data.format.container ? 'audio/' + data.format.container.toLowerCase() : 'audio/mp3',
             hashCode: value.hashCode,
           };
 
-          if (data.common.picture !== undefined && data.common.picture.length !== 0) {
-            //保存图片
-            savePicture(data, value, metadata, value.hashCode);
-            //获取文件类型
-            //TODO 如何做到同步，否则保存的时候，这里不一定set好
-            let picture = data.common.picture[0].data;
-            fileTypeFromBuffer(picture).then(res => {
-              metadata.pictureMime = res.mime
-              metadata.pictureExt = res.ext
-            })
+          if (data.common.picture?.length) {
+            await savePicture(data, metadata, value.hashCode);
           }
           metaList.push({ key: value.dir, value: metadata });
         }
       })
       .catch((err) => {
-        console.log(value);
-        console.log(err);
+        console.log(value.filePath, err.message);
       })
       .finally(() => {
-        mapSize -= 1;
         key += 1;
-        if (mapSize === 0) {
-          //回调前端
-          callback(metaList, event);
-        }
+        remaining -= 1;
+        if (remaining === 0) callback(metaList, event);
       });
   });
 }
 
-/**
- * 存储
- * @param fileList
- * @param event
- */
 function call(fileList, event) {
   if (fileList.length === 0) {
     event.reply(eventName.SYNC_DATA_CALLBACK.value, eventName.SYNC_DATA_CALLBACK.value);
     return;
   }
-  console.log("回调前端 排序开始")
   const groupedArray = Object.values(
     fileList.reduce((acc, obj) => {
       const { key, value } = obj;
       if (!acc[key]) {
-        acc[key] = { key: key, label: path.basename(key), value: [] };
+        acc[key] = { key, label: path.basename(key), value: [] };
       }
       acc[key].value.push(value);
       return acc;
     }, {})
   );
-  //排序
   groupedArray.sort((a, b) => a.label.localeCompare(b.label));
-  console.log("回调前端 排序结束")
 
   save(fileName.META_DATA.value, JSON.stringify(groupedArray), () => {
-    console.log("回调前端 SYNC_DATA_CALLBACK")
     event.reply(eventName.SYNC_DATA_CALLBACK.value, eventName.SYNC_DATA_CALLBACK.value);
   });
 }
 
-//同步数据
 const dataSyncAction = () => {
   ipcMain.on(eventName.SYNC_DATA.value, (event, data) => {
-    console.log("收到前端 SYNC_DATA")
-    if (data === undefined || data === null) {
+    if (!data) {
       event.reply(eventName.SYNC_DATA_CALLBACK.value, null);
       return;
     }
-    //找这些目录的音乐
     let fileList = batchReadDir(data);
-    // //解析元数据,存储
     parseMetaData(fileList, call, event);
   });
 };
-
-
 
 export { dataSyncAction };

--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -1,5 +1,6 @@
-const { app, BrowserWindow, Tray, Menu, nativeImage } = require("electron");
+const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain } = require("electron");
 const { join } = require("path");
+const fs = require("fs");
 
 process.env.DIST = join(__dirname, "../..");
 process.env.PUBLIC = app.isPackaged ? process.env.DIST : join(process.env.DIST, "../public");
@@ -52,12 +53,10 @@ function createWindow() {
     ],
     webPreferences: {
       preload,
-      webviewTag: true,
-      webSecurity: true, // 启用安全策略
-      nodeIntegration: true,
-      enableRemoteModule: true,
-      contextIsolation: false,
-      nodeIntegrationInSubFrames: true,
+      sandbox: false,
+      webSecurity: true,
+      nodeIntegration: false,
+      contextIsolation: true,
     },
   });
   loadFile();
@@ -89,6 +88,10 @@ function loadFile() {
 }
 
 app.whenReady().then(() => {
+  ipcMain.handle('read-file', async (event, filePath) => {
+    return fs.readFileSync(filePath);
+  });
+
   createWindow();
   const icon = nativeImage.createFromPath(join(process.env.PUBLIC, "/icons/music@6x.png"));
   const resizedIcon = icon.resize({ width: 128, height: 128 });

--- a/electron/preload/index.js
+++ b/electron/preload/index.js
@@ -1,30 +1,54 @@
-function domReady(condition = ['complete', 'interactive']) {
-  return new Promise(resolve => {
-    if (condition.includes(document.readyState)) {
-      resolve(true);
-    } else {
-      document.addEventListener('readystatechange', () => {
-        if (condition.includes(document.readyState)) {
-          resolve(true);
-        }
-      });
-    }
-  });
+const { contextBridge, ipcRenderer } = require('electron')
+const crypto = require('crypto')
+
+function formatTime(seconds) {
+  const totalSeconds = Math.floor(seconds)
+  const mins = Math.floor(totalSeconds / 60)
+  const secs = totalSeconds % 60
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
 }
 
+function getMd5Value(name) {
+  return crypto.createHash('md5').update(name).digest('hex')
+}
 
-import * as utilModule from '../lib/util/utils';
-import * as dataEvent from '../lib/metadata/event';
+function parseString(data) {
+  return typeof data === 'string' ? data : JSON.stringify(data)
+}
 
-/**
- * dom准备完毕
- */
-domReady().then(() => {
-  window.electron = require('electron')
-  window.fs = require('fs')
-  window.utils = utilModule
-  window.dataEvent = dataEvent
-});
+const replaceLive = (title) => {
+  if (!title) return null
+  return title.replace(/\（live\）/gi, '').replace(/\(live\)/gi, '')
+}
 
+const eventName = {
+  LOCAL_CONF_INIT: { label: "本地设置页面初始化", value: "localConfInit" },
+  OPEN_DIR: { label: "选择目录", value: "openDir" },
+  DIR_DATA_CALLBACK: { label: "发送目录数据给页面", value: "dirDataCallback" },
+  SYNC_DATA: { label: "同步数据", value: "syncData" },
+  SYNC_DATA_CALLBACK: { label: "同步数据回调", value: "syncDataCallBack" },
+  UPDATE_DIR: { label: "更新文件夹数据", value: "updateDir" },
+  UPDATE_DIR_CALLBACK: { label: "更新文件夹数据回调", value: "updateDirCallBack" },
+  INSTALL_LRC: { label: "下载歌词", value: "installLrc" },
+  INSTALL_LRC_CALLBACK: { label: "下载歌词回调", value: "installLrcBack" },
+  LOCAL: { label: "本地音乐", value: "local" },
+  LOCAL_CALLBACK: { label: "本地音乐回调", value: "localCallback" },
+  LRC: { label: "查询歌词", value: "lrc" },
+  LRC_CALLBACK: { label: "查询歌词回调", value: "lrcCallback" },
+  PRE: { label: "上一首", value: "pre" },
+  NEXT: { label: "下一首", value: "next" },
+  PLAY: { label: "播放/暂停", value: "play" },
+}
 
+contextBridge.exposeInMainWorld('electronAPI', {
+  ipcRenderer: {
+    send: (channel, data) => ipcRenderer.send(channel, data),
+    on: (channel, callback) => ipcRenderer.on(channel, callback),
+    removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
+    invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+  },
+  utils: { formatTime, getMd5Value, parseString, replaceLive },
+  readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
+})
 
+contextBridge.exposeInMainWorld('dataEvent', { eventName })

--- a/package.json
+++ b/package.json
@@ -10,29 +10,29 @@
     "build": "vite build && electron-builder --config electron/electron-builder.json5"
   },
   "devDependencies": {
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
-    "@vitejs/plugin-react": "^2.1.0",
-    "antd": "^5.6.1",
-    "electron": "29.1.6",
-    "electron-builder": "^24.13.3",
-    "electron-devtools-installer": "^3.2.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^5.2.0",
-    "sass": "^1.62.1",
-    "sass-loader": "^13.3.1",
-    "vite": "^3.1.0",
-    "vite-plugin-electron": "^0.9.3"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.7.0",
+    "antd": "^6.3.6",
+    "electron": "^41.3.0",
+    "electron-builder": "^26.8.1",
+    "electron-devtools-installer": "^4.0.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.2",
+    "sass": "^1.99.0",
+    "sass-loader": "^16.0.7",
+    "vite": "^5.4.21",
+    "vite-plugin-electron": "^0.29.1",
+    "vite-plugin-electron-renderer": "^0.14.6"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.15.14",
-    "file-type": "^19.0.0",
-    "mime-types": "^2.1.35",
-    "music-metadata": "^7.13.3",
-    "react-router-cache-route": "^1.12.11"
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
+    "file-type": "^19.6.0",
+    "mime-types": "^3.0.2",
+    "music-metadata": "^11.12.3"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,15 @@
 import Admin from "./compontes/Admin";
-import {HashRouter, Route, Switch} from "react-router-dom"
+import { HashRouter, Route, Routes, Navigate } from "react-router-dom";
 import zhCN from 'antd/locale/zh_CN';
-import {ConfigProvider} from "antd";
-import {createTheme, ThemeProvider} from '@mui/material/styles';
+import { ConfigProvider } from "antd";
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 
-// 创建自定义主题
 const theme = createTheme({
   components: {
     MuiSvgIcon: {
       styleOverrides: {
         root: {
-          fontSize: 16, // 设置图标的大小
+          fontSize: 16,
         },
       },
     },
@@ -22,9 +21,9 @@ export default function App() {
     <ConfigProvider locale={zhCN}>
       <ThemeProvider theme={theme}>
         <HashRouter>
-          <Switch>
-            <Route path="/" component={Admin}/>
-          </Switch>
+          <Routes>
+            <Route path="/*" element={<Admin />} />
+          </Routes>
         </HashRouter>
       </ThemeProvider>
     </ConfigProvider>

--- a/src/compontes/Admin.jsx
+++ b/src/compontes/Admin.jsx
@@ -1,47 +1,43 @@
-import React, {useState} from "react";
-
+import React, { useState } from "react";
+import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
 import LeftMenu from "@/compontes/left/LeftMenu";
-import {Redirect} from "react-router-dom";
 import Local from "@/compontes/center/Local";
 import Online from "@/compontes/center/Online";
-import {CacheRoute, CacheSwitch} from "react-router-cache-route";
-import {Layout} from "antd";
+import { Layout } from "antd";
 import MusicBar from "@/compontes/footer/Footer";
 import Playlist from "@/compontes/center/Playlist";
 import Love from "@/compontes/center/Love";
 import Lyrics from "@/compontes/footer/Lyrics";
 
-const {Footer, Sider, Content} = Layout;
+const { Footer, Sider, Content } = Layout;
 
 export default function Admin() {
-  //是否展示歌词页面
-  const [show, setShow] = useState(false)
-
-  const [metadata, setMetadata] = useState(null)
+  const [show, setShow] = useState(false);
+  const [metadata, setMetadata] = useState(null);
 
   const handleStatusChange = (status, metadata) => {
-    setShow(status)
-    setMetadata(metadata)
-  }
+    setShow(status);
+    setMetadata(metadata);
+  };
 
   return (
     <div>
-      <Lyrics show={show} metadata={metadata}/>
+      <Lyrics show={show} metadata={metadata} />
       <Layout>
         <Sider>
-          <LeftMenu/>
+          <LeftMenu />
         </Sider>
         <Content>
-          <CacheSwitch>
-            <Redirect from="/" exact to="/"/>
-            <CacheRoute path="/local" component={Local} style={{flex: 1}}/>
-            <CacheRoute path="/online" component={Online}/>
-            <CacheRoute path="/playlist" component={Playlist}/>
-            <CacheRoute path="/love" component={Love}/>
-          </CacheSwitch>
+          <Routes>
+            <Route path="/" element={<Navigate to="/local" replace />} />
+            <Route path="/local" element={<Local />} />
+            <Route path="/online" element={<Online />} />
+            <Route path="/playlist" element={<Playlist />} />
+            <Route path="/love" element={<Love />} />
+          </Routes>
         </Content>
         <Footer className="footer">
-          <MusicBar onStatusChange={handleStatusChange}/>
+          <MusicBar onStatusChange={handleStatusChange} />
         </Footer>
       </Layout>
     </div>

--- a/src/compontes/center/Local.jsx
+++ b/src/compontes/center/Local.jsx
@@ -46,17 +46,24 @@ export default function Local() {
   const [dirList, setDirList] = useState([]);
   const [dataSource, setDataSource] = useState([]);
   const dirListRef = useRef(dirList);
-  const [thisMusic, setThisMusic] = useState(null);
-  const [thisDir, setThisDir] = useState(null);
+  const [thisMusic, setThisMusic] = useState(() => eventManager.lastPlayed);
+  const [thisDir, setThisDir] = useState(() => eventManager.lastDir);
 
   useEffect(() => {
-    //查数据
-    electron.ipcRenderer.send(dataEvent.eventName.LOCAL.value, dataEvent.eventName.LOCAL.value);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.LOCAL.value, dataEvent.eventName.LOCAL.value);
 
-    //回调
-    electron.ipcRenderer.on(dataEvent.eventName.LOCAL_CALLBACK.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.LOCAL_CALLBACK.value, (event, data) => {
       setDirList(data);
       dirListRef.current = data;
+      // 恢复上次选中的目录和歌曲列表
+      const savedDir = eventManager.lastDir;
+      if (savedDir) {
+        const matched = data.find((item) => item.key === savedDir.key);
+        if (matched) {
+          setThisDir(matched);
+          setDataSource(matched.value);
+        }
+      }
     });
 
     //下一首
@@ -67,7 +74,7 @@ export default function Local() {
 
     // 取消订阅
     return () => {
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.LOCAL_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.LOCAL_CALLBACK.value);
       eventManager.unsubscribe(pageEvent.NEXT.value, handleNext);
       eventManager.unsubscribe(pageEvent.PRE.value, handlePre);
     };
@@ -112,7 +119,7 @@ export default function Local() {
    * @param data
    */
   const findLrc = (data) => {
-    electron.ipcRenderer.send(dataEvent.eventName.LRC.value, data);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.LRC.value, data);
   };
 
   /**
@@ -121,6 +128,7 @@ export default function Local() {
    */
   function tableRowClick(record) {
     setThisMusic(record);
+    eventManager.lastPlayed = record;
     eventManager.publish(pageEvent.CLICK_MUSIC.value, record);
     findLrc(record);
   }
@@ -128,25 +136,19 @@ export default function Local() {
   //文件夹列表点击
   const handleMenuClick = (record) => {
     setThisDir(record);
+    eventManager.lastDir = record;
     const selectedItem = dirList.find((item) => item.key === record.key);
     if (selectedItem) {
-      const { value } = selectedItem;
-      setDataSource(value);
+      setDataSource(selectedItem.value);
     }
   };
 
-  const rowClassName = (record, index) => {
-    if (thisMusic) {
-      return thisMusic === record ? "color-row" : "";
-    }
-    return "";
+  const rowClassName = (record) => {
+    return thisMusic && record.hashCode === thisMusic.hashCode ? "color-row" : "";
   };
 
-  const dirRowClassName = (record, index) => {
-    if (thisDir) {
-      return thisDir === record ? "color-row" : "";
-    }
-    return "";
+  const dirRowClassName = (record) => {
+    return thisDir && record.key === thisDir.key ? "color-row" : "";
   };
 
   return (

--- a/src/compontes/footer/Footer.jsx
+++ b/src/compontes/footer/Footer.jsx
@@ -20,7 +20,7 @@ import {
 import {getFileBlobByMetaData} from "@/util/filtUtils";
 
 const dataEvent = window.dataEvent;
-const utils = window.utils;
+const utils = window.electronAPI.utils;
 
 //播放模式枚举
 const IconMap = {
@@ -89,15 +89,15 @@ function Footer(props) {
     audioPlayer.addEventListener(pageEvent.TIME_UPDATE.value, updateProgress);
 
 
-    electron.ipcRenderer.on(dataEvent.eventName.NEXT.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.NEXT.value, (event, data) => {
       skipNext()
     });
 
-    electron.ipcRenderer.on(dataEvent.eventName.PRE.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.PRE.value, (event, data) => {
       skipPrevious()
     });
 
-    electron.ipcRenderer.on(dataEvent.eventName.PLAY.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.PLAY.value, (event, data) => {
       handlePlayPauseClick()
     });
 
@@ -105,16 +105,16 @@ function Footer(props) {
     return () => {
       eventManager.unsubscribe(pageEvent.CLICK_MUSIC.value, handleEvent);
       audioPlayer.removeEventListener(pageEvent.TIME_UPDATE.value, updateProgress);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.NEXT.value);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.PRE.value);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.PLAY.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.NEXT.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.PRE.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.PLAY.value);
     };
   }, [audioRef.current]);
 
   const handleEvent = (data) => {
     metadata.current = data;
-    // 处理事件
-    let {title, picture, path, duration} = data;
+    eventManager.lastPlayed = data;
+    let {title, picture, duration} = data;
     //设置属性
     setTitle(title);
     setDuration(duration);

--- a/src/compontes/footer/Lyrics.jsx
+++ b/src/compontes/footer/Lyrics.jsx
@@ -4,7 +4,8 @@ import icon from "/icons/music@6x.png";
 import pageEvent from "@/event/pageEvent";
 import eventManager from "@/event/eventManager";
 const dataEvent = window.dataEvent;
-import {resolvePictureToBase64} from "@/util/filtUtils";
+import {getFileBlobByMetaData} from "@/util/filtUtils";
+import {fileTypeEnum} from "@/enums/enums";
 
 export default function Lyrics(props) {
   /**
@@ -37,7 +38,7 @@ export default function Lyrics(props) {
     eventManager.subscribe(pageEvent.CURRENT_TIME.value, handleCurrentTime);
 
     //查询歌词
-    electron.ipcRenderer.on(dataEvent.eventName.LRC_CALLBACK.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.LRC_CALLBACK.value, (event, data) => {
       setLrc(data);
       lrcRef.current = data;
     });
@@ -45,17 +46,19 @@ export default function Lyrics(props) {
     return () => {
       eventManager.unsubscribe(pageEvent.CLICK_MUSIC.value, handleEvent);
       eventManager.unsubscribe(pageEvent.CURRENT_TIME.value, handleCurrentTime);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.LRC_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.LRC_CALLBACK.value);
     };
   }, []);
 
   const handleEvent = (data) => {
-    //放置当前播放歌曲元数据
     setMetadata(data);
-    //解析专辑为base64
-    resolvePictureToBase64(data.picture,(base64)=>{
-      setPicture(base64)
-    });
+    if (data.picture) {
+      getFileBlobByMetaData(data, fileTypeEnum.picture, (blobUrl) => {
+        setPicture(blobUrl);
+      });
+    } else {
+      setPicture(null);
+    }
   };
 
   /**
@@ -102,7 +105,7 @@ export default function Lyrics(props) {
     width: "100%",
     backdropFilter: "blur(8px)",
   };
-  if (metadata) {
+  if (picture) {
     containerStyle.backgroundImage = `url(${picture})`;
   }
   const lyricsClass = show ? "lyrics-container show" : "lyrics-container hide";
@@ -115,7 +118,7 @@ export default function Lyrics(props) {
             <div>
               <img
                 className="lrc-left-picture"
-                src={(metadata === null)||(metadata.picture === null) ? icon : `${picture}`}
+                src={picture ?? icon}
                 alt={icon}
               />
               <div className="lrc-left-info">

--- a/src/compontes/left/LeftMenu.jsx
+++ b/src/compontes/left/LeftMenu.jsx
@@ -1,80 +1,57 @@
-import React, {useState} from 'react'
-import {Divider, Image, Menu, Modal} from 'antd';
+import React, { useState } from 'react';
+import { Divider, Image, Menu, Modal } from 'antd';
 import Settings from "@/compontes/settings/Settings";
-import {withRouter} from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import icon from '/icons/music@6x.png';
-
-import {CloudQueue, FavoriteBorder, Headset, LibraryMusic} from '@mui/icons-material';
-
+import { CloudQueue, FavoriteBorder, Headset, LibraryMusic } from '@mui/icons-material';
 
 const items = [
-  {
-    label: "本地音乐",
-    key: "/local",
-    icon: <LibraryMusic/>,
-  },
-  {
-    label: "在线歌单",
-    key: "/online",
-    icon: <CloudQueue/>,
-  },
-  {
-    label: "播放列表",
-    key: "/playlist",
-    icon: <Headset/>,
-  },
-  {
-    label: "我喜欢的",
-    key: "/love",
-    icon: <FavoriteBorder/>,
-  }
+  { label: "本地音乐", key: "/local", icon: <LibraryMusic /> },
+  { label: "在线歌单", key: "/online", icon: <CloudQueue /> },
+  { label: "播放列表", key: "/playlist", icon: <Headset /> },
+  { label: "我喜欢的", key: "/love", icon: <FavoriteBorder /> },
 ];
 
-
-const LeftMenu = (props) => {
-  //模态框展示状态
-  const [open, setOpen] = useState(false)
+const LeftMenu = () => {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const menuClick = (event) => {
-    props.history.push(event.key)
+    navigate(event.key);
   };
-
 
   return (
     <div className={'leftBg heightMax'}>
       <div className={'center'}>
         <Image
           width={70}
-          onClick={() => {
-            setOpen(true)
-          }}
+          onClick={() => setOpen(true)}
           src={icon}
           preview={false}
         />
       </div>
-      <Divider/>
+      <Divider />
       <Menu
-        style={{border: 0}}
+        style={{ border: 0 }}
         theme="light"
         mode="inline"
         items={items}
+        selectedKeys={[location.pathname]}
         onClick={menuClick}
       />
       <Modal
-        bodyStyle={{height: '60vh', overflowY: 'auto'}}
+        styles={{ body: { height: '60vh', overflowY: 'auto' } }}
         width={'80%'}
         title="设置"
         open={open}
         footer={null}
-        onCancel={() => {
-          setOpen(false);
-        }}
+        onCancel={() => setOpen(false)}
       >
-
-        <Settings/>
+        <Settings />
       </Modal>
     </div>
-  )
-}
+  );
+};
 
-export default withRouter(LeftMenu);
+export default LeftMenu;

--- a/src/compontes/settings/LocalConf.jsx
+++ b/src/compontes/settings/LocalConf.jsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { Button, List, message, Space } from "antd";
-const dataEvent = window.dataEvent;
-
 import { Backspace } from "@mui/icons-material";
 
-const electron = window.electron;
+const dataEvent = window.dataEvent;
 
 export default function LocalConf() {
   const [localDir, setLocalDir] = useState([]);
@@ -17,64 +15,64 @@ export default function LocalConf() {
 
   useEffect(() => {
     //查数据
-    electron.ipcRenderer.send(dataEvent.eventName.LOCAL_CONF_INIT.value, dataEvent.eventName.LOCAL_CONF_INIT.value);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.LOCAL_CONF_INIT.value, dataEvent.eventName.LOCAL_CONF_INIT.value);
 
     //回调
-    electron.ipcRenderer.on(dataEvent.eventName.DIR_DATA_CALLBACK.value, (event, files) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.DIR_DATA_CALLBACK.value, (event, files) => {
       setLocalDir(files);
     });
 
     //回调
-    electron.ipcRenderer.on(dataEvent.eventName.SYNC_DATA_CALLBACK.value, (event, data) => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.SYNC_DATA_CALLBACK.value, (event, data) => {
       setLoading(false);
       message.success("同步成功", 2);
       if (data !== null) {
-        electron.ipcRenderer.send(dataEvent.LOCAL.value, dataEvent.LOCAL.value);
+        window.electronAPI.ipcRenderer.send(dataEvent.eventName.LOCAL.value, dataEvent.eventName.LOCAL.value);
       }
     });
 
     //回调
-    electron.ipcRenderer.on(dataEvent.eventName.INSTALL_LRC_CALLBACK.value, () => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.INSTALL_LRC_CALLBACK.value, () => {
       setLrcLoading(false);
       message.success("下载完成", 2);
     });
 
     //回调
-    electron.ipcRenderer.on(dataEvent.eventName.UPDATE_DIR_CALLBACK.value, () => {
+    window.electronAPI.ipcRenderer.on(dataEvent.eventName.UPDATE_DIR_CALLBACK.value, () => {
       message.success("更新文件夹数据成功", 2);
     });
 
     return () => {
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.DIR_DATA_CALLBACK.value);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.SYNC_DATA_CALLBACK.value);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.INSTALL_LRC_CALLBACK.value);
-      electron.ipcRenderer.removeAllListeners(dataEvent.eventName.UPDATE_DIR_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.DIR_DATA_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.SYNC_DATA_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.INSTALL_LRC_CALLBACK.value);
+      window.electronAPI.ipcRenderer.removeAllListeners(dataEvent.eventName.UPDATE_DIR_CALLBACK.value);
     };
   }, []);
 
   //同步数据
   const enterLoading = () => {
     setLoading(true);
-    electron.ipcRenderer.send(dataEvent.eventName.SYNC_DATA.value, localDir);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.SYNC_DATA.value, localDir);
   };
 
   //传递打开本地文件选择器选项
   const openDirSelect = () => {
     console.log("start");
-    electron.ipcRenderer.send(dataEvent.eventName.OPEN_DIR.value, dataEvent.eventName.OPEN_DIR.value);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.OPEN_DIR.value, dataEvent.eventName.OPEN_DIR.value);
   };
 
   //下载歌词
   const installLrc = () => {
     setLrcLoading(true);
-    electron.ipcRenderer.send(dataEvent.eventName.INSTALL_LRC.value, localDir);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.INSTALL_LRC.value, localDir);
   };
 
   //删除文件夹
   const removeDir = (dir) => {
     let data = localDir.filter((item) => item !== dir);
     setLocalDir(data);
-    electron.ipcRenderer.send(dataEvent.eventName.UPDATE_DIR.value, data);
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.UPDATE_DIR.value, data);
   };
 
   return (

--- a/src/event/eventManager.js
+++ b/src/event/eventManager.js
@@ -1,5 +1,7 @@
 const eventManager = {
     subscribers: {},
+    lastPlayed: null,
+    lastDir: null,
 
     subscribe(event, callback) {
         if (!this.subscribers[event]) {

--- a/src/strategy/listLoop.js
+++ b/src/strategy/listLoop.js
@@ -22,7 +22,7 @@ const localListLoop = (data) => {
     const nextMetaData = values[nextIndex];
     call(nextMetaData)
     eventManager.publish(pageEvent.CLICK_MUSIC.value, nextMetaData)
-    electron.ipcRenderer.send(dataEvent.eventName.LRC.value, nextMetaData)
+    window.electronAPI.ipcRenderer.send(dataEvent.eventName.LRC.value, nextMetaData)
   }
 }
 

--- a/src/strategy/playMode.js
+++ b/src/strategy/playMode.js
@@ -9,7 +9,7 @@ const dataEvent = window.dataEvent;
  */
 const singleLoop = (data) => {
   eventManager.publish(pageEvent.CLICK_MUSIC.value, data.metadata)
-  electron.ipcRenderer.send(dataEvent.eventName.LRC.value, data.metadata)
+  window.electronAPI.ipcRenderer.send(dataEvent.eventName.LRC.value, data.metadata)
 }
 
 function generateRandomNum(max, min) {
@@ -30,7 +30,7 @@ const random = (data) => {
     if (metadata) {
       call(metadata)
       eventManager.publish(pageEvent.CLICK_MUSIC.value, metadata)
-      electron.ipcRenderer.send(dataEvent.eventName.LRC.value, metadata)
+      window.electronAPI.ipcRenderer.send(dataEvent.eventName.LRC.value, metadata)
     }
   }
 }

--- a/src/util/filtUtils.js
+++ b/src/util/filtUtils.js
@@ -1,55 +1,26 @@
-import {fileTypeEnum} from "@/enums/enums";
+import { fileTypeEnum } from "@/enums/enums";
 
-const fs = window.fs;
-
-
-/**
- * 解析图片为base64
- * @param path
- * @param callback
- */
-function resolvePictureToBase64(path, callback) {
-  fs.readFile(path, (error, data) => {
-    if (error) {
-      console.error("Error reading file:", error);
-      return;
-    }
-    const base64String = Buffer.from(data).toString('base64');
-    const base64Info = `data:image/*;base64,${base64String}`;
-    callback(base64Info);
-  });
-}
-
-/**
- * 根据入参的元数据，获取文件blob数据
- * @param metadata
- * @param fileType
- * @param callback
- */
-function getFileBlobByMetaData(metadata, fileType, callback) {
-  //根据类型区分文件路径
-  let path ;
-  if (fileType === fileTypeEnum.picture){
-    path = metadata.picture
-  }else {
-    path = metadata.path
-  }
-  fs.readFile(path, (error, data) => {
-    if (error) {
-      console.error("Error reading file:", error);
-      return;
-    }
-    let mimeType = 'application/octet-stream';
-    if (fileType === fileTypeEnum.picture){
-      mimeType = metadata.pictureMime
-    }else {
-      mimeType = metadata.mime
-    }
-    const blob = new Blob([data], {type: mimeType});
+async function getFileBlobByMetaData(metadata, fileType, callback) {
+  const filePath = fileType === fileTypeEnum.picture ? metadata.picture : metadata.path;
+  try {
+    const data = await window.electronAPI.readFile(filePath);
+    const mimeType = fileType === fileTypeEnum.picture ? metadata.pictureMime : metadata.mime;
+    const blob = new Blob([data], { type: mimeType });
     callback(URL.createObjectURL(blob));
-  });
+  } catch (error) {
+    console.error("Error reading file:", error);
+  }
 }
 
-export {
-  getFileBlobByMetaData,resolvePictureToBase64
+async function resolvePictureToBase64(filePath, callback) {
+  if (!filePath) return;
+  try {
+    const data = await window.electronAPI.readFile(filePath);
+    const base64String = Buffer.from(data).toString('base64');
+    callback(`data:image/*;base64,${base64String}`);
+  } catch (error) {
+    console.error("Error reading picture:", error);
+  }
 }
+
+export { getFileBlobByMetaData, resolvePictureToBase64 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,39 +1,34 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import electron from 'vite-plugin-electron'
-// https://vitejs.dev/config/
-export default defineConfig({
-    resolve: {
-        alias: {
-            '@': path.join(__dirname, 'src'),
-        },
-    },
-    plugins: [
-        react(),
-        electron({
-            main: {
-                entry: 'electron/main/index.js',
-                vite: {
-                    build: {
-                        outDir: 'dist/electron/main',
-                    }
-                },
-            },
-            preload: {
-                input: {
-                    // You can configure multiple preload scripts here
-                    index: path.join(__dirname, 'electron/preload/index.js'),
-                },
-                vite: {
-                    build: {
-                        outDir: 'dist/electron/preload',
-                    }
-                },
-            },
+import electron from 'vite-plugin-electron/simple'
 
-            // Enables use of Node.js API in the Electron-Renderer
-            renderer: {},
-        })
-    ]
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.join(__dirname, 'src'),
+    },
+  },
+  plugins: [
+    react(),
+    electron({
+      main: {
+        entry: 'electron/main/index.js',
+        vite: {
+          build: {
+            outDir: 'dist/electron/main',
+          },
+        },
+      },
+      preload: {
+        input: path.join(__dirname, 'electron/preload/index.js'),
+        vite: {
+          build: {
+            outDir: 'dist/electron/preload',
+          },
+        },
+      },
+      renderer: {},
+    }),
+  ],
 })


### PR DESCRIPTION
- 升级 electron 29→41、vite 3→5、react-router-dom 5→7、antd 5→6、music-metadata 7→11 等全部依赖
- 修复 Electron 安全漏洞：启用 contextIsolation，关闭 nodeIntegration，preload 改用 contextBridge 暴露 API
- 修复 dataSyncAction 中 fileTypeFromBuffer 未 await 导致图片 MIME 未设置的 bug
- 修复 fs.js saveSync 错误的回调写法，修复 utils.js instanceof String 判断失效问题
- 迁移 react-router-dom v7，移除 withRouter/Switch/Redirect，改用 useNavigate/Routes
- 修复歌词页面专辑图片不显示的问题
- 修复切换页面后当前播放歌曲高亮丢失、选中目录丢失的问题