### PR TITLE
chore: 优化打包配置与 CI/CD 流程

### DIFF
--- a/.github/changelog.md
+++ b/.github/changelog.md
@@ -4,6 +4,24 @@
 
 ### 新增：
 
+## [1.2.0] - 2026-04-25
+
+### 新增：
+升级 electron 29→41、vite 3→5、react-router-dom 5→7、antd 5→6、music-metadata 7→11 等全部依赖
+
+修复 Electron 安全漏洞：启用 contextIsolation，关闭 nodeIntegration，preload 改用 contextBridge 暴露 API
+
+修复 dataSyncAction 中 fileTypeFromBuffer 未 await 导致图片 MIME 未设置的 bug
+
+修复 fs.js saveSync 错误的回调写法，修复 utils.js instanceof String 判断失效问题
+
+迁移 react-router-dom v7，移除 withRouter/Switch/Redirect，改用 useNavigate/Routes
+
+修复歌词页面专辑图片不显示的问题
+
+修复切换页面后当前播放歌曲高亮丢失、选中目录丢失的问题
+
+
 ### 修改：
 
 * 本地文件列表调整组件，更紧凑

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,57 +3,81 @@ name: Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     environment: package
     strategy:
+      fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        include:
+          - os: windows-latest
+            platform: win
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: mac
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: '20.x'
+          cache: 'npm'
 
-      - name: Install
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (Windows)
+        if: matrix.platform == 'win'
+        run: npm run build -- --win
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: npm run build
+      - name: Build (Linux)
+        if: matrix.platform == 'linux'
+        run: npm run build -- --linux
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # step5: 清理
-      - name: Cleanup artifacts
-        run: |
-          Get-ChildItem -Path "release" | Where-Object { $_.Name -NotMatch ".*\.(zip|tar\.gz|AppImage)" } | Remove-Item -Force -Recurse
-        if: matrix.os == 'windows-latest'
+      - name: Build (macOS)
+        if: matrix.platform == 'mac'
+        run: npm run build -- --mac
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cleanup artifacts
-        run: npx rimraf "release/!(*.zip|*.tar.gz|*.AppImage)"
-        if: matrix.os == 'ubuntu-latest'
-
-      # step6: 上传
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}
-          path: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS }}
+          name: release-${{ matrix.platform }}
+          path: |
+            release/*.zip
+            release/*.tar.gz
+            release/*.AppImage
+            release/*.dmg
+            release/*.exe
+          if-no-files-found: warn
 
-      # step7: 发布
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          files: "release/**"
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron/electron-builder.json5
+++ b/electron/electron-builder.json5
@@ -2,49 +2,68 @@
  * @see https://www.electron.build/configuration/configuration
  */
 {
-  appId: "electron-music",
-  productName: "electron-music",
+  appId: "com.chalmery.electron-music",
+  productName: "ElectronMusic",
   copyright: "Copyright © 2023 ${author}",
   asar: true,
+  compression: "maximum",
+  removePackageScripts: true,
   directories: {
     output: "release",
     buildResources: "public"
   },
   files: [
-    "dist"
+    "dist/**/*"
   ],
   win: {
     icon: "public/icons/music@x6.png",
-    artifactName: "${productName}-win-${version}.${ext}",
+    artifactName: "${productName}-win-${version}-${arch}.${ext}",
     target: [
       {
         target: "zip",
-        arch: [
-          "x64"
-        ]
+        arch: ["x64"]
+      },
+      {
+        target: "nsis",
+        arch: ["x64"]
       }
     ]
   },
+  nsis: {
+    oneClick: false,
+    allowToChangeInstallationDirectory: true,
+    deleteAppDataOnUninstall: false
+  },
   mac: {
-    icon: 'public/icons/music@x6.png',
-    category: 'Productivity',
+    icon: "public/icons/music@x6.png",
+    category: "public.app-category.music",
+    artifactName: "${productName}-mac-${version}-${arch}.${ext}",
+    hardenedRuntime: true,
+    gatekeeperAssess: false,
     target: [
       {
-        target: 'default',
-        arch: [
-          'arm64',
-          'x64'
-        ]
+        target: "dmg",
+        arch: ["arm64", "x64"]
+      },
+      {
+        target: "zip",
+        arch: ["arm64", "x64"]
       }
     ]
   },
   linux: {
     icon: "public/icons/music@x6.png",
+    category: "Audio",
+    artifactName: "${productName}-linux-${version}-${arch}.${ext}",
     target: [
-      "AppImage",
-      "tar.gz"
-    ],
-    "category": "Audio",
-    artifactName: "${productName}-Linux-${version}.${ext}"
+      {
+        target: "AppImage",
+        arch: ["x64"]
+      },
+      {
+        target: "tar.gz",
+        arch: ["x64"]
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "electron-music",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "electron音乐播放器",
   "main": "dist/electron/main/index.js",
   "author": "chalmery, Inc <chaochaoycc@gmail.com>",
   "scripts": {
     "dev": "vite",
     "build": "vite build && electron-builder --config electron/electron-builder.json5"
+
   },
   "devDependencies": {
     "@types/react": "^19.2.14",


### PR DESCRIPTION
- 升级 GitHub Actions 至最新版本（checkout/setup-node/upload-artifact v4，softprops/action-gh-release v2）
- CI 新增 macOS 构建，拆分 build/publish 两阶段，publish 等三平台全部完成后统一发布
- 改用内置 GITHUB_TOKEN，移除自定义 secret 依赖
- tag 触发格式改为 v*.*.* 规范格式
- electron-builder：appId 改为反向域名格式，新增 nsis 安装包目标，Mac 改为 dmg+zip，加 hardenedRuntime，统一 artifact 命名含 arch
- 版本号修正为 1.2.0（符合 semver）